### PR TITLE
fix: replace deprecated String.prototype.substr()

### DIFF
--- a/index.js
+++ b/index.js
@@ -64,7 +64,7 @@ class Walker extends EE {
     this.entries = entries
     if (entries.length === 0) {
       if (this.includeEmpty) {
-        this.result.add(this.path.substr(this.root.length + 1))
+        this.result.add(this.path.slice(this.root.length + 1))
       }
       this.emit('done', this.result)
     } else {
@@ -156,7 +156,7 @@ class Walker extends EE {
     const abs = this.path + '/' + entry
     if (!st.isDirectory()) {
       if (file) {
-        this.result.add(abs.substr(this.root.length + 1))
+        this.result.add(abs.slice(this.root.length + 1))
       }
       then()
     } else {


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.