### PR TITLE
fix: trim ignore rules before matching

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -108,7 +108,9 @@ class Walker extends EE {
     }
     const rules = data.split(/\r?\n/)
       .filter(line => !/^#|^$/.test(line.trim()))
-      .map(r => new Minimatch(r, mmopt))
+      .map(rule => {
+        return new Minimatch(rule.trim(), mmopt)
+      })
 
     this.ignoreRules[file] = rules
 

--- a/test/ignore-spaces.js
+++ b/test/ignore-spaces.js
@@ -1,0 +1,34 @@
+'use strict'
+const walk = require('..')
+const { resolve } = require('path')
+const path = resolve(__dirname, 'fixtures')
+
+// set the ignores just for this test
+const c = require('./common.js')
+c.ignores({
+  'd/.ignore-spaces': [' h'],
+})
+
+// the files that we expect to not see
+const notAllowed = [
+  /^d\/h\/.*/,
+]
+
+const t = require('tap')
+
+t.test('async', t => walk({
+  path,
+  ignoreFiles: ['.ignore-spaces'],
+}, (er, result) => {
+  result.forEach(r => notAllowed.forEach(na =>
+    t.notMatch(r, na, r + ' !~ ' + na)))
+}))
+
+t.test('sync', t => {
+  walk.sync({
+    path,
+    ignoreFiles: ['.ignore-spaces'],
+  }).forEach(r => notAllowed.forEach(na =>
+    t.notMatch(r, na, r + ' !~ ' + na)))
+  t.end()
+})


### PR DESCRIPTION
Looks like the latest minimatch doesn't do this anymore.
