### PR TITLE
fix: disallow child unignoring parent directory ignore

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -217,6 +217,9 @@ class Walker extends EE {
     if (this.parent && this.parent.filterEntry) {
       var pt = this.basename + '/' + entry
       included = this.parent.filterEntry(pt, partial)
+      if (!included && partial) {
+        return false
+      }
     }
 
     this.ignoreFiles.forEach(f => {

--- a/test/preserve-ignores.js
+++ b/test/preserve-ignores.js
@@ -1,0 +1,30 @@
+'use strict'
+
+var walk = require('../lib/index.js')
+const { resolve } = require('path')
+const path = resolve(__dirname, 'fixtures')
+
+// set the ignores just for this test
+var c = require('./common.js')
+c.ignores({
+  '.ignore': ['*', '!/c', '!/d'],
+  'c/.ignore': ['!*', '.ignore'], // unignore everything
+})
+
+// the only files we expect to see
+var expected = []
+
+const t = require('tap')
+
+t.test('sync', t => {
+  t.same(walk.sync({
+    path,
+    ignoreFiles: ['.ignore'],
+  }), expected)
+  t.end()
+})
+
+t.test('async', t => walk({
+  path,
+  ignoreFiles: ['.ignore'],
+}, (er, result) => t.same(result, expected)))


### PR DESCRIPTION
This solves issues with `npm pack` (this library is used by [npm-packlist](https://github.com/npm/npm-packlist) which implements the command).

## References
Related to npm/cli#7007
