### PR TITLE
fix: recursive directory ignore rules

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -208,15 +208,16 @@ class Walker extends EE {
     new Walker(this.walkerOpt(entry, opts)).on('done', then).start()
   }
 
-  filterEntry (entry, partial) {
+  filterEntry (entry, partial, entryBasename) {
     let included = true
 
     // this = /a/b/c
     // entry = d
     // parent /a/b sees c/d
     if (this.parent && this.parent.filterEntry) {
-      var pt = this.basename + '/' + entry
-      included = this.parent.filterEntry(pt, partial)
+      const parentEntry = this.basename + '/' + entry
+      const parentBasename = entryBasename || entry
+      included = this.parent.filterEntry(parentEntry, partial, parentBasename)
       if (!included && partial) {
         return false
       }
@@ -229,17 +230,30 @@ class Walker extends EE {
           // so if it's negated, and already included, no need to check
           // likewise if it's neither negated nor included
           if (rule.negate !== included) {
+            const isRelativeRule = !entryBasename
+              ? undefined // not required (optimization)
+              : rule.globParts.some(part => {
+                  const isDirectoryPart = !part.slice(-1)[0]
+                  return part.length <= (isDirectoryPart ? 2 : 1)
+                })
             // first, match against /foo/bar
             // then, against foo/bar
             // then, in the case of partials, match with a /
+            //   then, if also the rule is relative, match against basename
             const match = rule.match('/' + entry) ||
               rule.match(entry) ||
-              (!!partial && (
+              !!partial && (
                 rule.match('/' + entry + '/') ||
-                rule.match(entry + '/'))) ||
-              (!!partial && rule.negate && (
-                rule.match('/' + entry, true) ||
-                rule.match(entry, true)))
+                rule.match(entry + '/') ||
+                rule.negate && (
+                  rule.match('/' + entry, true) ||
+                  rule.match(entry, true)) ||
+                isRelativeRule && (
+                  rule.match('/' + entryBasename + '/') ||
+                  rule.match(entryBasename + '/') ||
+                  rule.negate && (
+                    rule.match('/' + entryBasename, true) ||
+                    rule.match(entryBasename, true))))
 
             if (match) {
               included = rule.negate

--- a/lib/index.js
+++ b/lib/index.js
@@ -233,9 +233,9 @@ class Walker extends EE {
             const isRelativeRule = !entryBasename
               ? undefined // not required (optimization)
               : rule.globParts.some(part => {
-                  const isDirectoryPart = !part.slice(-1)[0]
-                  return part.length <= (isDirectoryPart ? 2 : 1)
-                })
+                const isDirectoryPart = !part.slice(-1)[0]
+                return part.length <= (isDirectoryPart ? 2 : 1)
+              })
             // first, match against /foo/bar
             // then, against foo/bar
             // then, in the case of partials, match with a /
@@ -248,7 +248,7 @@ class Walker extends EE {
                 rule.negate && (
                   rule.match('/' + entry, true) ||
                   rule.match(entry, true)) ||
-                isRelativeRule && (
+                !!isRelativeRule && (
                   rule.match('/' + entryBasename + '/') ||
                   rule.match(entryBasename + '/') ||
                   rule.negate && (

--- a/lib/index.js
+++ b/lib/index.js
@@ -230,12 +230,10 @@ class Walker extends EE {
           // so if it's negated, and already included, no need to check
           // likewise if it's neither negated nor included
           if (rule.negate !== included) {
-            const isRelativeRule = !entryBasename
-              ? undefined // not required (optimization)
-              : rule.globParts.some(part => {
-                const isDirectoryPart = !part.slice(-1)[0]
-                return part.length <= (isDirectoryPart ? 2 : 1)
-              })
+            const isRelativeRule = entryBasename && rule.globParts.some(part =>
+              part.length <= (part.slice(-1)[0] ? 1 : 2)
+            )
+
             // first, match against /foo/bar
             // then, against foo/bar
             // then, in the case of partials, match with a /
@@ -248,7 +246,7 @@ class Walker extends EE {
                 rule.negate && (
                   rule.match('/' + entry, true) ||
                   rule.match(entry, true)) ||
-                !!isRelativeRule && (
+                isRelativeRule && (
                   rule.match('/' + entryBasename + '/') ||
                   rule.match(entryBasename + '/') ||
                   rule.negate && (

--- a/test/common.js
+++ b/test/common.js
@@ -6,11 +6,13 @@ if (require.main === module) {
 
 const fs = require('fs')
 const path = require('path')
+const mkdirp = require('mkdirp')
 
 exports.ignores = ignores
 exports.writeIgnoreFile = writeIgnoreFile
 exports.writeIgnores = writeIgnores
 exports.clearIgnores = clearIgnores
+exports.createFile = createFile
 
 function writeIgnoreFile (file, rules) {
   file = path.resolve(__dirname, 'fixtures', file)
@@ -36,4 +38,14 @@ function clearIgnores (set) {
 function ignores (set) {
   writeIgnores(set)
   process.on('exit', clearIgnores.bind(null, set))
+}
+
+/** Used to create an extra file next to the fixtures from 00-setup.js. */
+function createFile (dir, file) {
+  var fixtures = path.resolve(__dirname, 'fixtures')
+
+  dir = path.resolve(fixtures, dir)
+  mkdirp.sync(dir)
+  file = path.resolve(dir, file)
+  fs.writeFileSync(file, path.basename(file))
 }

--- a/test/common.js
+++ b/test/common.js
@@ -6,7 +6,6 @@ if (require.main === module) {
 
 const fs = require('fs')
 const path = require('path')
-const mkdirp = require('mkdirp')
 
 exports.ignores = ignores
 exports.writeIgnoreFile = writeIgnoreFile
@@ -45,7 +44,7 @@ function createFile (dir, file) {
   var fixtures = path.resolve(__dirname, 'fixtures')
 
   dir = path.resolve(fixtures, dir)
-  mkdirp.sync(dir)
+  fs.mkdirSync(dir, { recursive: true })
   file = path.resolve(dir, file)
   fs.writeFileSync(file, path.basename(file))
 }

--- a/test/nested-ignores.js
+++ b/test/nested-ignores.js
@@ -7,16 +7,24 @@ const path = resolve(__dirname, 'fixtures')
 // set the ignores just for this test
 var c = require('./common.js')
 c.ignores({
-  '.ignore': ['*', 'd', 'h', '!d/c/h/.dch', '!/h/c/d/hcd'],
+  '.ignore': ['*', 'd', 'h', '!d/c/h/.dch', '!/h/c/d/hcd', '!c/**/ccc'],
   'd/.ignore': ['!*', '.ignore'], // unignore everything
   'd/d/.ignore': ['*'], // re-ignore everything
   'd/c/.ignore': ['*', '!/h/.dch'], // original unignore
   'd/h/.ignore': ['*'], // ignore everything again
   'h/c/d/.ignore': ['!hcd', '!.hcd', '!/d{ch,dd}'],
+  'c/.ignore': ['h/', 'c/c*'], // ignore directories recursively (GH#9)
 })
+// For GH#9, we need one more level of depth
+c.createFile('c/c/d/d', 'ccc')
+c.createFile('c/c/d/h', 'ccc')
 
 // the only files we expect to see
 var expected = [
+  'c/c/d/ccc',
+  'c/c/d/d/ccc',
+  'c/d/c/ccc',
+  'c/d/d/ccc',
   'd/c/h/.dch',
   'h/c/d/.hcd',
   'h/c/d/dch',


### PR DESCRIPTION
This is a rebase and cleanup of #16

---

Citing from the [gitignore docs](http://git-scm.com/docs/gitignore#_pattern_format#:~:text=If%20there%20is%20a%20separator%20at%20the%20beginning%20or%20middle%20(or%20both)%20of%20the%20pattern%2C%20then%20the%20pattern%20is%20relative%20to%20the%20directory%20level%20of%20the%20particular%20.gitignore%20file%20itself.%20Otherwise%20the%20pattern%20may%20also%20match%20at%20any%20level%20below%20the%20.gitignore%20level.):

> If there is a separator at the beginning or middle (or both) of the pattern, then the pattern is relative to the directory level of the particular `.gitignore` file itself. Otherwise the pattern may also match at any level below the `.gitignore` level.

Previously, parent walkers were only passed the resolved path to a file
entry via  filterEntry()`. This patch also passes the entry's basename
which is matched against the rule if it is relative.

Regression tests are included as well.

Closes #9.