### PR TITLE
fix: handling of nested unignores

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -22,6 +22,7 @@ class Walker extends EE {
     this.result = this.parent ? this.parent.result : new Set()
     this.entries = null
     this.sawError = false
+    this.exact = opts.exact
   }
 
   sort (a, b) {
@@ -164,7 +165,7 @@ class Walker extends EE {
     } else {
       // is a directory
       if (dir) {
-        this.walker(entry, { isSymbolicLink }, then)
+        this.walker(entry, { isSymbolicLink, exact: file || this.filterEntry(entry + '/') }, then)
       } else {
         then()
       }
@@ -218,7 +219,7 @@ class Walker extends EE {
       const parentEntry = this.basename + '/' + entry
       const parentBasename = entryBasename || entry
       included = this.parent.filterEntry(parentEntry, partial, parentBasename)
-      if (!included && partial) {
+      if (!included && !this.exact) {
         return false
       }
     }

--- a/test/nested-ignores.js
+++ b/test/nested-ignores.js
@@ -26,9 +26,6 @@ var expected = [
   'c/d/c/ccc',
   'c/d/d/ccc',
   'd/c/h/.dch',
-  'h/c/d/.hcd',
-  'h/c/d/dch',
-  'h/c/d/ddd',
   'h/c/d/hcd',
 ]
 

--- a/test/nested-unignores.js
+++ b/test/nested-unignores.js
@@ -7,12 +7,25 @@ const path = resolve(__dirname, 'fixtures')
 // set the ignores just for this test
 var c = require('./common.js')
 c.ignores({
-  '.ignore': ['*', '!/c', '!/d'],
+  '.ignore': ['*', '!/c/d', '!/d/c', '!/d/d/', '!/d/h/h'],
   'c/.ignore': ['!*', '.ignore'], // unignore everything
+  'd/c/.ignore': ['!h', '!cc*'], // unignore directory
+  'd/d/.ignore': ['!h/', '!cc*'], // unignore directory with slash
+  'd/h/h/.ignore': ['!dd*'], // unignore files
 })
 
 // the only files we expect to see
-var expected = []
+var expected = [
+  'd/c/h/ccc',
+  'd/c/h/ccd',
+  'd/c/h/cch',
+  'd/d/h/ccc',
+  'd/d/h/ccd',
+  'd/d/h/cch',
+  'd/h/h/ddc',
+  'd/h/h/ddd',
+  'd/h/h/ddh',
+]
 
 const t = require('tap')
 


### PR DESCRIPTION
The fix in #116 was not quite complete. git does allow unignoring directories as long as its path to the root is unignored. This modifies the check to handle this case. The test case in `nested-ignores.js` was indeed wrong because it interpreted unignoring a specific file `!/h/c/d/hcd` as unignoring the directory `!/h/c/d`. I added new tests that specifically unignore a directory and therefore allow unignoring anything else within it.

## References
Related to #116
